### PR TITLE
Missing header for builds not using PCH files

### DIFF
--- a/src/cpp/RiderLink/Source/RiderGameControlExtension/Private/RiderGameControlExtension.cpp
+++ b/src/cpp/RiderLink/Source/RiderGameControlExtension/Private/RiderGameControlExtension.cpp
@@ -20,6 +20,7 @@
 #include "LevelEditorViewport.h"
 #else
 #include "IAssetViewport.h"
+#include "EditorViewportClient.h"
 #endif
 
 #define LOCTEXT_NAMESPACE "RiderLink"
@@ -235,7 +236,7 @@ static void RequestPlay(int mode)
     if (!bSpawnAtPlayerStart && SlateApplication && ActiveLevelViewport.IsValid() &&
         SlateApplication->FindWidgetWindow(ActiveLevelViewport->AsWidget()).IsValid())
     {
-#if ENGINE_MINOR_VERSION < 24
+#if ENGINE_MAJOR_VERSION == 4 && ENGINE_MINOR_VERSION <= 23
         StartLocation = &ActiveLevelViewport->GetLevelViewportClient().GetViewLocation();
         StartRotation = &ActiveLevelViewport->GetLevelViewportClient().GetViewRotation();
 #else


### PR DESCRIPTION
Missing header when compiling a project that is not using precompiled headers.
Modified also the second compilation conditional to match first one.