### PR TITLE
Fix building RaiderLink on case sensitive file systems

### DIFF
--- a/src/cpp/RiderLink/Source/RiderLink/Private/ProtocolFactory.cpp
+++ b/src/cpp/RiderLink/Source/RiderLink/Private/ProtocolFactory.cpp
@@ -3,7 +3,7 @@
 #include "scheduler/base/IScheduler.h"
 #include "wire/SocketWire.h"
 
-#include "HAL/PlatformFilemanager.h"
+#include "HAL/PlatformFileManager.h"
 #include "Misc/App.h"
 #include "Misc/FileHelper.h"
 #include "Misc/Paths.h"


### PR DESCRIPTION
RiderLink fails building on Linux due to a miscased import.