### PR TITLE
Fix RiderLink compilation in UE4.27.

### DIFF
--- a/src/cpp/RiderLink/Source/RD/thirdparty/spdlog/include/spdlog/fmt/bundled/chrono.h
+++ b/src/cpp/RiderLink/Source/RD/thirdparty/spdlog/include/spdlog/fmt/bundled/chrono.h
@@ -1547,6 +1547,11 @@ OutputIt format_duration_unit(OutputIt out) {
   return out;
 }
 
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable:4582 4583)
+#endif
+
 class get_locale {
  private:
   union {
@@ -1566,6 +1571,10 @@ class get_locale {
     return has_locale_ ? locale_ : get_classic_locale();
   }
 };
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 
 template <typename FormatContext, typename OutputIt, typename Rep,
           typename Period>

--- a/src/cpp/RiderLink/Source/RD/thirdparty/spdlog/include/spdlog/fmt/bundled/core.h
+++ b/src/cpp/RiderLink/Source/RD/thirdparty/spdlog/include/spdlog/fmt/bundled/core.h
@@ -1204,6 +1204,11 @@ template <typename Context> struct custom_value {
   void (*format)(void* arg, parse_context& parse_ctx, Context& ctx);
 };
 
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable:4582 4583)
+#endif
+
 // A formatting argument value.
 template <typename Context> class value {
  public:
@@ -1282,6 +1287,10 @@ template <typename Context> class value {
     ctx.advance_to(f.format(*static_cast<qualified_type*>(arg), ctx));
   }
 };
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 
 template <typename Context, typename T>
 FMT_CONSTEXPR auto make_arg(const T& value) -> basic_format_arg<Context>;


### PR DESCRIPTION
Disable warnings 4582 and 4583 as it's done in UE5