### PR TITLE
Unreal log console color settings page

### DIFF
--- a/src/rider/main/kotlin/com/jetbrains/rider/plugins/unreal/toolWindow/log/UnrealLogConsoleViewContentType.kt
+++ b/src/rider/main/kotlin/com/jetbrains/rider/plugins/unreal/toolWindow/log/UnrealLogConsoleViewContentType.kt
@@ -1,0 +1,27 @@
+package com.jetbrains.rider.plugins.unreal.toolWindow.log
+
+import com.intellij.execution.ui.ConsoleViewContentType
+import com.intellij.openapi.editor.colors.TextAttributesKey
+import org.jetbrains.annotations.NonNls
+
+class UnrealLogConsoleViewContentType(@NonNls name: String, textAttributesKey: TextAttributesKey)
+    : ConsoleViewContentType(name, textAttributesKey) {
+
+    companion object {
+        val UE_LOG_FATAL_KEY = TextAttributesKey.createTextAttributesKey("UE_LOG_FATAL", LOG_ERROR_OUTPUT_KEY)
+        val UE_LOG_ERROR_KEY = TextAttributesKey.createTextAttributesKey("UE_LOG_ERROR", LOG_ERROR_OUTPUT_KEY)
+        val UE_LOG_WARNING_KEY = TextAttributesKey.createTextAttributesKey("UE_LOG_WARNING", LOG_WARNING_OUTPUT_KEY)
+        val UE_LOG_DISPLAY_KEY = TextAttributesKey.createTextAttributesKey("UE_LOG_DISPLAY", LOG_INFO_OUTPUT_KEY)
+        val UE_LOG_LOG_KEY = TextAttributesKey.createTextAttributesKey("UE_LOG_LOG", LOG_INFO_OUTPUT_KEY)
+        val UE_LOG_VERBOSE_KEY = TextAttributesKey.createTextAttributesKey("UE_LOG_VERBOSE", LOG_DEBUG_OUTPUT_KEY)
+        val UE_LOG_VERY_VERBOSE_KEY = TextAttributesKey.createTextAttributesKey("UE_LOG_VERY_VERBOSE", LOG_DEBUG_OUTPUT_KEY)
+
+        val UE_LOG_FATAL = UnrealLogConsoleViewContentType("UE_LOG_FATAL", UE_LOG_FATAL_KEY)
+        val UE_LOG_ERROR = UnrealLogConsoleViewContentType("UE_LOG_ERROR", UE_LOG_ERROR_KEY)
+        val UE_LOG_WARNING = UnrealLogConsoleViewContentType("UE_LOG_WARNING", UE_LOG_WARNING_KEY)
+        val UE_LOG_DISPLAY = UnrealLogConsoleViewContentType("UE_LOG_DISPLAY", UE_LOG_DISPLAY_KEY)
+        val UE_LOG_LOG = UnrealLogConsoleViewContentType("UE_LOG_LOG", UE_LOG_LOG_KEY)
+        val UE_LOG_VERBOSE = UnrealLogConsoleViewContentType("UE_LOG_VERBOSE", UE_LOG_VERBOSE_KEY)
+        val UE_LOG_VERY_VERBOSE = UnrealLogConsoleViewContentType("UE_LOG_VERY_VERBOSE", UE_LOG_VERY_VERBOSE_KEY)
+    }
+}

--- a/src/rider/main/kotlin/com/jetbrains/rider/plugins/unreal/toolWindow/log/UnrealLogPanel.kt
+++ b/src/rider/main/kotlin/com/jetbrains/rider/plugins/unreal/toolWindow/log/UnrealLogPanel.kt
@@ -162,14 +162,14 @@ class UnrealLogPanel(val tabModel: String, lifetime: Lifetime, val project: Proj
 
     private fun getMessageStyle(type: VerbosityType): ConsoleViewContentType {
         return when (type) {
-            VerbosityType.Fatal -> ConsoleViewContentType.LOG_ERROR_OUTPUT
-            VerbosityType.Error -> ConsoleViewContentType.LOG_ERROR_OUTPUT
-            VerbosityType.Warning -> ConsoleViewContentType.LOG_WARNING_OUTPUT
-            VerbosityType.Display -> ConsoleViewContentType.LOG_INFO_OUTPUT
-            VerbosityType.Log -> ConsoleViewContentType.LOG_INFO_OUTPUT
-            VerbosityType.Verbose -> ConsoleViewContentType.LOG_DEBUG_OUTPUT
-            VerbosityType.VeryVerbose -> ConsoleViewContentType.LOG_DEBUG_OUTPUT
-            else -> ConsoleViewContentType.LOG_INFO_OUTPUT
+            VerbosityType.Fatal -> UnrealLogConsoleViewContentType.UE_LOG_FATAL
+            VerbosityType.Error -> UnrealLogConsoleViewContentType.UE_LOG_ERROR
+            VerbosityType.Warning -> UnrealLogConsoleViewContentType.UE_LOG_WARNING
+            VerbosityType.Display -> UnrealLogConsoleViewContentType.UE_LOG_DISPLAY
+            VerbosityType.Log -> UnrealLogConsoleViewContentType.UE_LOG_LOG
+            VerbosityType.Verbose -> UnrealLogConsoleViewContentType.UE_LOG_VERBOSE
+            VerbosityType.VeryVerbose -> UnrealLogConsoleViewContentType.UE_LOG_VERY_VERBOSE
+            else -> UnrealLogConsoleViewContentType.UE_LOG_LOG
         }
     }
 

--- a/src/rider/main/kotlin/com/jetbrains/rider/settings/UnrealLogColorSettingsPage.kt
+++ b/src/rider/main/kotlin/com/jetbrains/rider/settings/UnrealLogColorSettingsPage.kt
@@ -1,0 +1,89 @@
+package com.jetbrains.rider.settings
+
+import com.intellij.execution.impl.ConsoleViewUtil
+import com.intellij.openapi.editor.colors.EditorColorsScheme
+import com.intellij.openapi.editor.colors.TextAttributesKey
+import com.intellij.openapi.fileTypes.PlainSyntaxHighlighter
+import com.intellij.openapi.fileTypes.SyntaxHighlighter
+import com.intellij.openapi.options.colors.AttributesDescriptor
+import com.intellij.openapi.options.colors.ColorDescriptor
+import com.intellij.openapi.options.colors.ColorSettingsPage
+import com.intellij.openapi.util.NlsSafe
+import com.jetbrains.rider.UnrealLinkBundle
+import com.jetbrains.rider.plugins.unreal.toolWindow.log.UnrealLogConsoleViewContentType
+import icons.UnrealIcons
+import javax.swing.Icon
+
+
+@Suppress("UnstableApiUsage")
+class UnrealLogColorSettingsPage : ColorSettingsPage {
+    companion object {
+        // These names are from UE enumeration and should not be localized
+        private const val FATAL: @NlsSafe String = "Fatal"
+        private const val ERROR: @NlsSafe String = "Error"
+        private const val WARNING: @NlsSafe String = "Warning"
+        private const val DISPLAY: @NlsSafe String = "Display"
+        private const val LOG: @NlsSafe String = "Log"
+        private const val VERBOSE: @NlsSafe String = "Verbose"
+        private const val VERY_VERBOSE: @NlsSafe String = "VeryVerbose"
+
+        private val ATTR_DESCRIPTORS: Array<AttributesDescriptor> = arrayOf(
+                AttributesDescriptor(FATAL, UnrealLogConsoleViewContentType.UE_LOG_FATAL_KEY),
+                AttributesDescriptor(ERROR, UnrealLogConsoleViewContentType.UE_LOG_ERROR_KEY),
+                AttributesDescriptor(WARNING, UnrealLogConsoleViewContentType.UE_LOG_WARNING_KEY),
+                AttributesDescriptor(DISPLAY, UnrealLogConsoleViewContentType.UE_LOG_DISPLAY_KEY),
+                AttributesDescriptor(LOG, UnrealLogConsoleViewContentType.UE_LOG_LOG_KEY),
+                AttributesDescriptor(VERBOSE, UnrealLogConsoleViewContentType.UE_LOG_VERBOSE_KEY),
+                AttributesDescriptor(VERY_VERBOSE, UnrealLogConsoleViewContentType.UE_LOG_VERY_VERBOSE_KEY),
+        )
+
+        private val ADDITIONAL_HIGHLIGHT_DESCRIPTORS: Map<String, TextAttributesKey> = mapOf(
+                "fatal" to UnrealLogConsoleViewContentType.UE_LOG_FATAL_KEY,
+                "error" to UnrealLogConsoleViewContentType.UE_LOG_ERROR_KEY,
+                "warning" to UnrealLogConsoleViewContentType.UE_LOG_WARNING_KEY,
+                "display" to UnrealLogConsoleViewContentType.UE_LOG_DISPLAY_KEY,
+                "log" to UnrealLogConsoleViewContentType.UE_LOG_LOG_KEY,
+                "verbose" to UnrealLogConsoleViewContentType.UE_LOG_VERBOSE_KEY,
+                "very_verbose" to UnrealLogConsoleViewContentType.UE_LOG_VERY_VERBOSE_KEY,
+        )
+    }
+
+    override fun getDisplayName(): String {
+        return UnrealLinkBundle.message("color.settings.unreal.console.name")
+    }
+
+    override fun getAttributeDescriptors(): Array<AttributesDescriptor> {
+        return ATTR_DESCRIPTORS
+    }
+
+    override fun getColorDescriptors(): Array<ColorDescriptor> {
+        return emptyArray()
+    }
+
+    override fun getHighlighter(): SyntaxHighlighter {
+        return PlainSyntaxHighlighter()
+    }
+
+    override fun getAdditionalHighlightingTagToDescriptorMap(): Map<String, TextAttributesKey> {
+        return ADDITIONAL_HIGHLIGHT_DESCRIPTORS
+    }
+
+    override fun getDemoText(): String {
+        return """
+            
+            <fatal>UE_LOG(LogCategory, Fatal, TEXT("Message"));</fatal>
+            <error>UE_LOG(LogCategory, Error, TEXT("Message"));</error>
+            <warning>UE_LOG(LogCategory, Warning, TEXT("Message"));</warning>
+            <display>UE_LOG(LogCategory, Display, TEXT("Message"));</display>
+            <log>UE_LOG(LogCategory, Log, TEXT("Message"));</log>
+            <verbose>UE_LOG(LogCategory, Verbose, TEXT("Message"));</verbose>
+            <very_verbose>UE_LOG(LogCategory, VeryVerbose, TEXT("Message"));</very_verbose>
+        """.trimIndent()
+    }
+
+    override fun getIcon(): Icon = UnrealIcons.Status.UnrealEngineLogo
+
+    override fun customizeColorScheme(scheme: EditorColorsScheme): EditorColorsScheme {
+        return ConsoleViewUtil.updateConsoleColorScheme(scheme)
+    }
+}

--- a/src/rider/main/resources/META-INF/plugin.xml
+++ b/src/rider/main/resources/META-INF/plugin.xml
@@ -187,6 +187,7 @@ Path to old plugin:</code></pre>
                                  instance="com.jetbrains.rider.settings.UnrealLinkSettingsConfigurable"/>
         <projectConfigurable groupId="tools" id="UnrealLogSettings" bundle="messages.UnrealLinkBundle"
                              instance="com.jetbrains.rider.settings.UnrealLogSettingsConfigurable"/>
+        <colorSettingsPage implementation="com.jetbrains.rider.settings.UnrealLogColorSettingsPage" id="unreal_log"/>
 
         <consoleActionsPostProcessor
                 implementation="com.jetbrains.rider.plugins.unreal.toolWindow.log.UnrealLogConsoleActionsPostProcessor"/>

--- a/src/rider/main/resources/messages/UnrealLinkBundle.properties
+++ b/src/rider/main/resources/messages/UnrealLinkBundle.properties
@@ -66,3 +66,5 @@ configurable.UnrealLink.showTimestampsCheckbox.label=Show message timestamps
 configurable.UnrealLink.showVerbosityCheckbox.label=Show message verbosity types
 configurable.UnrealLink.alignMessagesCheckbox.label=Align log messages by category of maximum of
 configurable.UnrealLink.alignMessagesCheckbox.label.ending=characters wide
+
+color.settings.unreal.console.name=Unreal Log


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/830406/189442325-597cc0ca-f455-449b-9083-81a38bcbd759.png)
New settings page to configure colors of all unreal engine logs verbosity types.
By default colors are inherited from default console logging settings, but color for each unreal verbosity can be overridden.