### PR TITLE
Proper fix for building RiderLink on Windows for UE5.2 or later

### DIFF
--- a/src/cpp/RiderLink/Source/RiderLogging/RiderLogging.Build.cs
+++ b/src/cpp/RiderLink/Source/RiderLogging/RiderLogging.Build.cs
@@ -16,10 +16,12 @@ public class RiderLogging : ModuleRules
 			bUseRTTI = false;
 		}
 		else
+		{
+			bUseRTTI = true;
+		}
 #endif
-        {
-		    bUseRTTI = true;
-        }
+        bUseRTTI = true;
+        
 
 		PrivateDependencyModuleNames.AddRange(new []
 		{


### PR DESCRIPTION
"else" is hanging for no reason before `#endif`. We need to explicitly set `bUseRTTI` to `true` in `else` branch for UE5.2, so on Windows RTTI will be used for UE5.2 or later