### PR TITLE
Fix for missing include in RiderOutputDevice.cpp

### DIFF
--- a/src/cpp/RiderLink/Source/RiderLogging/Private/RiderOutputDevice.cpp
+++ b/src/cpp/RiderLink/Source/RiderLogging/Private/RiderOutputDevice.cpp
@@ -1,6 +1,7 @@
 #include "RiderOutputDevice.hpp"
 
 #include "CoreGlobals.h"
+#include "ScopeLock.h"
 #include "Misc/OutputDeviceRedirector.h"
 
 void FRiderOutputDevice::Serialize(const TCHAR* V, ELogVerbosity::Type Verbosity, const FName& Category)


### PR DESCRIPTION
`#include "ScopeLock.h"` line was missing