### PR TITLE
Proper include inserted to fix unresolved FScopeLock

### DIFF
--- a/src/cpp/RiderLink/Source/RiderLogging/Private/RiderOutputDevice.cpp
+++ b/src/cpp/RiderLink/Source/RiderLogging/Private/RiderOutputDevice.cpp
@@ -1,7 +1,7 @@
 #include "RiderOutputDevice.hpp"
 
 #include "CoreGlobals.h"
-#include "ScopeLock.h"
+#include "Misc/ScopeLock.h"
 #include "Misc/OutputDeviceRedirector.h"
 
 void FRiderOutputDevice::Serialize(const TCHAR* V, ELogVerbosity::Type Verbosity, const FName& Category)


### PR DESCRIPTION
In some project `#include "ScopeLock.h"` couldn't be resolved, so the fix is to use full path to include starting with `Misc` folder