### PR TITLE
Disable Static Analysis for the UE modules

### DIFF
--- a/src/cpp/RiderLink/Source/RD/RD.Build.cs
+++ b/src/cpp/RiderLink/Source/RD/RD.Build.cs
@@ -9,6 +9,10 @@ public class RD : ModuleRules
 		bUseRTTI = true;
 
 #if UE_5_2_OR_LATER
+		bDisableStaticAnalysis = true;
+#endif
+
+#if UE_5_2_OR_LATER
 		IWYUSupport = IWYUSupport.KeepAsIs;
 #else
 		bEnforceIWYU = false;

--- a/src/cpp/RiderLink/Source/RiderBlueprint/RiderBlueprint.Build.cs
+++ b/src/cpp/RiderLink/Source/RiderBlueprint/RiderBlueprint.Build.cs
@@ -11,6 +11,10 @@ public class RiderBlueprint : ModuleRules
 #endif
 		
 		bUseRTTI = true;
+
+#if UE_5_2_OR_LATER
+		bDisableStaticAnalysis = true;
+#endif
 		
 		PublicDependencyModuleNames.Add("RD");
 

--- a/src/cpp/RiderLink/Source/RiderGameControl/RiderGameControl.Build.cs
+++ b/src/cpp/RiderLink/Source/RiderGameControl/RiderGameControl.Build.cs
@@ -12,6 +12,10 @@ public class RiderGameControl : ModuleRules
 		
 		bUseRTTI = true;
 
+#if UE_5_2_OR_LATER
+		bDisableStaticAnalysis = true;
+#endif
+
 		PublicDependencyModuleNames.Add("Core");
 
 		PrivateDependencyModuleNames.AddRange(new []

--- a/src/cpp/RiderLink/Source/RiderLC/RiderLC.Build.cs
+++ b/src/cpp/RiderLink/Source/RiderLC/RiderLC.Build.cs
@@ -12,6 +12,10 @@ public class RiderLC : ModuleRules
 
         bUseRTTI = true;
 
+#if UE_5_2_OR_LATER
+		bDisableStaticAnalysis = true;
+#endif
+
         PrivateDefinitions.Add("_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING");
         PrivateDefinitions.Add("_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS");
         PrivateDependencyModuleNames.AddRange(

--- a/src/cpp/RiderLink/Source/RiderLink/RiderLink.Build.cs
+++ b/src/cpp/RiderLink/Source/RiderLink/RiderLink.Build.cs
@@ -13,6 +13,10 @@ public class RiderLink : ModuleRules
 		
 		bUseRTTI = true;
 
+#if UE_5_2_OR_LATER
+		bDisableStaticAnalysis = true;
+#endif
+
 		PublicDependencyModuleNames.Add("Core");
 		PublicDependencyModuleNames.Add("RD");
 		string[] Paths = {

--- a/src/cpp/RiderLink/Source/RiderLogging/RiderLogging.Build.cs
+++ b/src/cpp/RiderLink/Source/RiderLogging/RiderLogging.Build.cs
@@ -21,6 +21,10 @@ public class RiderLogging : ModuleRules
 		    bUseRTTI = true;
         }
 
+#if UE_5_2_OR_LATER
+		bDisableStaticAnalysis = true;
+#endif
+
 		PrivateDependencyModuleNames.AddRange(new []
 		{
 			"Core",

--- a/src/cpp/RiderLink/Source/RiderShaderInfo/RiderShaderInfo.Build.cs
+++ b/src/cpp/RiderLink/Source/RiderShaderInfo/RiderShaderInfo.Build.cs
@@ -9,6 +9,11 @@ public class RiderShaderInfo : ModuleRules
 #else
 		PCHUsage = PCHUsageMode.NoSharedPCHs;
 #endif
+
+#if UE_5_2_OR_LATER
+		bDisableStaticAnalysis = true;
+#endif
+
 		PrivateDependencyModuleNames.AddRange(new string[] { "Core",  "Projects", "RenderCore" });
 	}
 }


### PR DESCRIPTION
When we run Static Analysis locally, it also runs it on RiderLink, and reports issues in its ThirdParty code.

This PR turns SA off for the Unreal modules, as these issues are not relevant or actionable for the project.