### PR TITLE
Fix hang on editor crash

### DIFF
--- a/src/cpp/RiderLink/Source/RiderLogging/Private/RiderOutputDevice.hpp
+++ b/src/cpp/RiderLink/Source/RiderLogging/Private/RiderOutputDevice.hpp
@@ -16,6 +16,7 @@ using FOnSerializeMessage =
 
 class FRiderOutputDevice : public FOutputDevice {
 public:
+	~FRiderOutputDevice();
 	void Setup(TFunction<FOnSerializeMessage::TFuncType>);
 	virtual void TearDown() override;
 


### PR DESCRIPTION
In the past months every time my editor crashed, it has hanged and I had to kill it from the Task Manager. I finally had time to investigate, and there is a deadlock caused by `FRiderOutputDevice`.

The events leading to the deadlock (i.e. if `debug crash` command is run):
- `FWindowsPlatformMisc::RequestExitWithStatus` calls `GLog->TearDown()`
- `TearDown` locks output devices with `LockOutputDevices`, then proceeds to `OutputDevice->TearDown()` for all devices
- `FRiderOutputDevice::TearDown` calls `GLog->RemoveOutputDevice(this)`
- `RemoveOutputDevice` sleeps forever due to `OutputDevicesLockCounter == 1` that's locked by `GLog->TearDown()`

I've solved it by moving `GLog->RemoveOutputDevice(this)` to the constructor, as that's how `FOutputLogHistory : public FOutputDevice` handles this case too.