### PR TITLE
Fix link error using Clang 16.0.5 on Windows

### DIFF
--- a/src/cpp/RiderLink/Source/RD/src/rd_framework_cpp/src/main/scheduler/SynchronousScheduler.cpp
+++ b/src/cpp/RiderLink/Source/RD/src/rd_framework_cpp/src/main/scheduler/SynchronousScheduler.cpp
@@ -20,4 +20,10 @@ bool SynchronousScheduler::is_active() const
 {
 	return SynchronousScheduler_active_count > 0;
 }
+
+SynchronousScheduler& SynchronousScheduler::Instance()
+{
+	static SynchronousScheduler globalSynchronousScheduler;
+	return globalSynchronousScheduler;
+}
 }	 // namespace rd

--- a/src/cpp/RiderLink/Source/RD/src/rd_framework_cpp/src/main/scheduler/SynchronousScheduler.h
+++ b/src/cpp/RiderLink/Source/RD/src/rd_framework_cpp/src/main/scheduler/SynchronousScheduler.h
@@ -32,11 +32,7 @@ public:
 	/**
 	 * \brief global synchronous scheduler for whole application.
 	 */
-	static SynchronousScheduler& Instance()
-	{
-		static SynchronousScheduler globalSynchronousScheduler;
-		return globalSynchronousScheduler;
-	}
+	static SynchronousScheduler& Instance();
 };
 
 }	 // namespace rd


### PR DESCRIPTION
When using Clang on Windows with Unreal Engine, RiderLink fails to link:
```
[74/76] Link [x64] UnrealEditor-RiderBlueprint.dll
lld-link: error: undefined symbol: class rd::SynchronousScheduler `public: static class rd::SynchronousScheduler & __cdecl rd::SynchronousScheduler::Instance(void)'::`2'::globalSynchronousScheduler
>>> referenced by C:\Users\...\AppData\Local\Temp\UnrealLink\Pyvexys\HostProject\Plugins\RiderLink\Source\RD\src\rd_framework_cpp\src\main\task\RdCall.h:74
>>>               C:\Users\...\AppData\Local\Temp\UnrealLink\Pyvexys\HostProject\Plugins\RiderLink\Intermediate\Build\Win64\x64\UnrealEditor\Development\RiderBlueprint\Module.RiderBlueprint.cpp.obj:(public: class rd::WiredRdTask<bool, class rd::Polymorphic<bool, void>> __cdecl rd::RdCall<int, bool, class rd::Polymorphic<int, void>, class rd::Polymorphic<bool, void>>::sync(int const &, class std::chrono::duration<__int64, struct std::ratio<1, 1000>>) const)
>>> referenced by C:\Users\...\AppData\Local\Temp\UnrealLink\Pyvexys\HostProject\Plugins\RiderLink\Source\RD\src\rd_framework_cpp\src\main\task\WiredRdTaskImpl.h:65
>>>               C:\Users\...\AppData\Local\Temp\UnrealLink\Pyvexys\HostProject\Plugins\RiderLink\Intermediate\Build\Win64\x64\UnrealEditor\Development\RiderBlueprint\Module.RiderBlueprint.cpp.obj:(public: virtual class rd::IScheduler * __cdecl rd::detail::WiredRdTaskImpl<bool, class rd::Polymorphic<bool, void>>::get_wire_scheduler(void) const)
```

Moving the static singleton definition to the `.cpp` file fixes this.