### PR TITLE
Fix Unreferenced Formal Parameter warning

### DIFF
--- a/src/cpp/RiderLink/Source/RiderDebuggerSupport/Private/DebugLogger.cpp
+++ b/src/cpp/RiderLink/Source/RiderDebuggerSupport/Private/DebugLogger.cpp
@@ -12,7 +12,7 @@ extern "C" __declspec(dllimport) void __stdcall OutputDebugStringA(const char* L
 
 #endif
 
-void RiderDebuggerSupport::SendLogToDebugger(const char* FormatStr, ...)
+void RiderDebuggerSupport::SendLogToDebugger([[maybe_unused]] const char* FormatStr, ...)
 {
 #if JB_DEBUG_MODE
 


### PR DESCRIPTION
There's this compiler warning reported for the FormatStr parameter (if `JB_DEBUG_MODE` is `0`, which is the default) under MSVC 14: `Unreferenced Formal Parameter`.

Marking it as `maybe_unused` resolves this.