### PR TITLE
Fix RiderLink RD module crash in some case when load UE4 editor.

### DIFF
--- a/src/cpp/RiderLink/Source/RD/RD.Build.cs
+++ b/src/cpp/RiderLink/Source/RD/RD.Build.cs
@@ -66,6 +66,7 @@ public class RD : ModuleRules
 		PrivateDefinitions.Add("rd_core_cpp_EXPORTS");
 		PrivateDefinitions.Add("spdlog_EXPORTS");
 		PrivateDefinitions.Add("FMT_EXPORT");
+		PrivateDefinitions.Add("_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR");
 
 		PublicDefinitions.Add("SPDLOG_NO_EXCEPTIONS");
 		PublicDefinitions.Add("SPDLOG_COMPILED_LIB");


### PR DESCRIPTION
In some case, UE4 will crash when load RiderLink. This may be caused by incompatible MSVC version.
https://stackoverflow.com/questions/78598141/first-stdmutexlock-crashes-in-application-built-with-latest-visual-studio

crash stack.
```C++
<unknown> 0x00007ffc6a1d2f70
spdlog::details::registry::initialize_logger(shared_ptr<spdlog::logger>) registry-inl.h:61
spdlog::synchronous_factory::create<spdlog::sinks::wincolor_stderr_sink<spdlog::details::console_mutex>, enum spdlog::color_mode &>(basic_string<char, std::char_traits<char>, std::allocator<char> >, spdlog::color_mode &) synchronous_factory.h:20
spdlog::stderr_color_mt<spdlog::synchronous_factory>(const std::string &, color_mode) stdout_color_sinks-inl.h:30
<lambda_79917a11...>::operator()() Lifetime.cpp:23
rd::Lifetime::Lifetime(bool) Lifetime.cpp:22
[Inlined] rd::LifetimeDefinition::{ctor}(bool) LifetimeDefinition.cpp:7
rd::`anonymous namespace'::`dynamic initializer for 'ETERNAL''() LifetimeDefinition.cpp:33
FWindowsPlatformProcess::LoadLibraryWithSearchPaths(const FString &, const TArray<FString, TSizedDefaultAllocator<32> > &) WindowsPlatformProcess.cpp:1889
FWindowsPlatformProcess::GetDllHandle(const wchar_t *) WindowsPlatformProcess.cpp:91
FModuleManager::LoadModuleWithFailureReason(FName, EModuleLoadResult &) ModuleManager.cpp:506
FModuleDescriptor::LoadModulesForPhase(Type, const TArray<FModuleDescriptor, TSizedDefaultAllocator<32> > &, TMap<FName, enum EModuleLoadResult, FDefaultSetAllocator, TDefaultMapHashableKeyFuncs<FName, enum EModuleLoadResult, 0> > &) ModuleDescriptor.cpp:560
FPluginManager::TryLoadModulesForPlugin(const FPlugin &, Type) PluginManager.cpp:1355
FPluginManager::LoadModulesForEnabledPlugins(Type) PluginManager.cpp:1431
FEngineLoop::LoadStartupModules() LaunchEngineLoop.cpp:3969
FEngineLoop::PreInitPostStartupScreen(const wchar_t *) LaunchEngineLoop.cpp:3344
[Inlined] FEngineLoop::PreInit(const wchar_t *) LaunchEngineLoop.cpp:3752
[Inlined] EnginePreInit(const wchar_t *) Launch.cpp:45
GuardedMain(const wchar_t *) Launch.cpp:130
WinMain(HINSTANCE__ *, HINSTANCE__ *, char *, int) LaunchWindows.cpp:275
```
